### PR TITLE
Adição da expiração no SVID

### DIFF
--- a/poclib/svid/dasvid.go
+++ b/poclib/svid/dasvid.go
@@ -178,7 +178,6 @@ func VerifySignature(jwtToken string, key JWK) error {
 
 // Mint a new DASVID
 func Mintdasvid(kid string, iss string, sub string, dpa string, dpr string, oam []byte, zkp string, exp int64, key interface{}) string {
-	log.Printf("exp (entrada no dasvid.go): %v", exp)
 	defer timeTrack(time.Now(), "Mintdasvid")
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)

--- a/poclib/svid/dasvid.go
+++ b/poclib/svid/dasvid.go
@@ -177,19 +177,20 @@ func VerifySignature(jwtToken string, key JWK) error {
 }
 
 // Mint a new DASVID
-func Mintdasvid(kid string, iss string, sub string, dpa string, dpr string, oam []byte, zkp string, key interface{}) string {
+func Mintdasvid(kid string, iss string, sub string, dpa string, dpr string, oam []byte, zkp string, exp int64, key interface{}) string {
+	log.Printf("exp (entrada no dasvid.go): %v", exp)
 	defer timeTrack(time.Now(), "Mintdasvid")
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	// Set issue and exp time
 	issue_time := time.Now().Round(0).Unix()
-	exp_time := time.Now().Add(time.Minute * 2).Round(0).Unix()
+	exp_time := exp
 
 	// Declaring flags
 	issuer := flag.String("iss", iss, "issuer(iss) = SPIFFE ID of the workload that generated the DA-SVID (Asserting workload")
 	assert := flag.Int64("aat", issue_time, "asserted at(aat) = time at which the assertion made in the DA-SVID was verified by the asserting workload")
-	exp := flag.Int64("exp", exp_time, "expiration time(exp) = as small as reasonably possible, issue time + 1s by default.")
+	expiration := flag.Int64("exp", exp_time, "expiration time(exp) = as small as reasonably possible, issue time + 1s by default.")
 	subj := flag.String("sub", sub, "subject (sub) = the identity about which the assertion is being made. Subject workload's SPIFFE ID.")
 	dlpa := flag.String("dpa", dpa, "delegated authority (dpa) = ")
 	dlpr := flag.String("dpr", dpr, "delegated principal (dpr) = The Principal")
@@ -202,7 +203,7 @@ func Mintdasvid(kid string, iss string, sub string, dpa string, dpr string, oam 
 		proof := flag.String("zkp", zkp, "OAuth Zero-Knowledge-Proof")
 
 		token = mint.NewWithClaims(mint.SigningMethodRS256, mint.MapClaims{
-			"exp": *exp,
+			"exp": *expiration,
 			"iss": *issuer,
 			"aat": *assert,
 			"sub": *subj,
@@ -217,7 +218,7 @@ func Mintdasvid(kid string, iss string, sub string, dpa string, dpr string, oam 
 
 	} else {
 		token = mint.NewWithClaims(mint.SigningMethodRS256, mint.MapClaims{
-			"exp": *exp,
+			"exp": *expiration,
 			"iss": *issuer,
 			"aat": *assert,
 			"sub": *subj,

--- a/samples/SVID-NG/Assertingwl-mTLS/handlers/MintHandler.go
+++ b/samples/SVID-NG/Assertingwl-mTLS/handlers/MintHandler.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"strconv"
 
 	"github.com/hpe-usp-spire/signed-assertions/SVID-NG/Assertingwl-mTLS/models"
 	"github.com/hpe-usp-spire/signed-assertions/SVID-NG/api-libs/global"
@@ -128,6 +129,11 @@ func MintHandler(w http.ResponseWriter, r *http.Request) {
 				message := []byte(strings.Join(parts[0:2], "."))
 
 				// Generate DASVID claims
+				expFloat, err := strconv.ParseFloat(fmt.Sprintf("%v", tokenclaims["exp"]), 64)
+				if err != nil {
+					log.Printf("Error to convert expString to expFloat...")
+				}
+				exp := int64(expFloat)
 				iss := assertingwl.ID.String()
 				sub := clientspiffeid.String()
 				dpa := fmt.Sprintf("%v", issuer)
@@ -141,9 +147,9 @@ func MintHandler(w http.ResponseWriter, r *http.Request) {
 				if global.Options.AddZKP == "true" {
 					log.Printf("Adding ZKP into DASVID...")
 					// Generate DASVID
-					token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, oam, zkp, awprivatekey)
+					token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, oam, zkp, exp, awprivatekey)
 				} else {
-					token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, nil, "", awprivatekey)
+					token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, nil, "", exp, awprivatekey)
 				}
 
 				// Data to be write in cache file
@@ -155,13 +161,18 @@ func MintHandler(w http.ResponseWriter, r *http.Request) {
 
 			} else {
 				// Generate DASVID claims
+				expFloat, err := strconv.ParseFloat(fmt.Sprintf("%v", tokenclaims["exp"]), 64)
+				if err != nil {
+					log.Printf("Error to convert expString to expFloat...")
+				}
+				exp := int64(expFloat)
 				iss := assertingwl.ID.String()
 				sub := clientspiffeid.String()
 				dpa := fmt.Sprintf("%v", issuer)
 				dpr := fmt.Sprintf("%v", tokenclaims["sub"])
 
 				// Generate DASVID
-				token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, nil, "", awprivatekey)
+				token = dasvid.Mintdasvid(kid, iss, sub, dpa, dpr, nil, "", exp, awprivatekey)
 
 				// Data to be write in cache file
 				fileTemp = models.FileContents{


### PR DESCRIPTION
Foi realizada a inserção de um campo de expiração no SVID baseado na expiração do OAuthToken. Por enquanto, somente para a SVID-NG sample.